### PR TITLE
Avoid else if when the browserlanguage has not even been assigned

### DIFF
--- a/js/browser-redirect-geoip.js
+++ b/js/browser-redirect-geoip.js
@@ -81,7 +81,7 @@ jQuery(document).ready(function()
 
                         redirectUrl = languageUrls[browserLanguage];
                     }
-                    else if (languageUrls[browserLanguage.substr(0, 2)] != undefined)
+                    else if (browserLanguage && browserLanguage != 'undefined' && languageUrls[browserLanguage.substr(0, 2)] != undefined)
                     {
                         if(GEOIP_DEBUG)
                             console.log("Found redirection in conditional 2");


### PR DESCRIPTION
Having the unwanted effect of ie. endless pre-loaders based on JS that hang on variables not assigned waiting for window/doc loaded. 

Real life example: https://www.austinfraser.com/en/blog-what-is-artificial-intelligence/